### PR TITLE
fix: change images to not read_only

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       args:
         SGX_MODE: "SW"
       target: run-sgx-wallet-server-sw
-    read_only: true
+    read_only: false
     init: true
     environment:
       BIND_ADDR: "0.0.0.0:8000"
@@ -33,7 +33,7 @@ services:
       args:
         SGX_MODE: "HW"
       target: run-sgx-wallet-server-hw
-    read_only: true
+    read_only: false
     init: true
     environment:
       BIND_ADDR: "0.0.0.0:8000"


### PR DESCRIPTION
Getting following error:
```
SgxFile::create failed with error: Os { code: 30, kind: ReadOnlyFilesystem, message: "Read-only file system" }
Error when trying to create the sender's file: SGX_ERROR_UNEXPECTED
Deserialized data: Err(Error("EOF while parsing a value", line: 1, column: 0))
```

This PR should fix this.